### PR TITLE
python -> python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installation
 ```
 git clone https://github.com/Askannz/msi-perkeyrgb
 cd msi-perkeyrgb/
-sudo python setup.py install
+sudo python3 setup.py install
 sudo cp 99-msi-rgb.rules /etc/udev/rules.d/
 ```
 
@@ -128,6 +128,11 @@ If the same key is configured differently by multiple lines, the lowest line tak
 Lines prefixed with `#` are ignored.
 
 #### Examples
+
+Create file config
+```
+touch configKeyboard.py
+```
 
 All keys white except yellow arrows and orange "Fn" key.
 ```


### PR DESCRIPTION
If you want use Python 3.4+, so in ubuntu 18.04 you have to install `setup.py`, with python3 and not simple python.
And, I never code in Python, so you never tell us, what file type create: .txt, .py, .xls ...
Tks for this project.