### PR TITLE
Replace non-existant `id_str` with id from args

### DIFF
--- a/msi_perkeyrgb/msi_perkeyrgb.py
+++ b/msi_perkeyrgb/msi_perkeyrgb.py
@@ -87,7 +87,7 @@ def main():
                     print("No USB device with ID %s found." % args.id)
                 sys.exit(1)
             except HIDOpenError:
-                print("Cannot open keyboard. Possible causes :\n- You don't have permissions to open the HID device. Run this program as root, or give yourself read/write permissions to the corresponding /dev/hidraw*. If you have just installed this tool, reboot your computer for the udev rule to take effect.\n- USB device with id %s is not a HID device." % id_str)
+                print("Cannot open keyboard. Possible causes :\n- You don't have permissions to open the HID device. Run this program as root, or give yourself read/write permissions to the corresponding /dev/hidraw*. If you have just installed this tool, reboot your computer for the udev rule to take effect.\n- USB device with id %s is not a HID device." % args.id)
                 sys.exit(1)
 
             # If user has requested disabling


### PR DESCRIPTION
Fix NameError when failing due to running without permissions.

```
$ msi-perkeyrgb      
No laptop model specified, using GE63 as default.
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/msi_perkeyrgb/msi_perkeyrgb.py", line 79, in main
    kb = MSI_Keyboard(usb_id, msi_keymap, msi_presets)
  File "/usr/lib/python3.7/site-packages/msi_perkeyrgb/msi_keyboard.py", line 45, in __init__
    self._hid_keyboard = HID_Keyboard(usb_id)
  File "/usr/lib/python3.7/site-packages/msi_perkeyrgb/hidapi_wrapping.py", line 58, in __init__
    raise HIDOpenError
msi_perkeyrgb.hidapi_wrapping.HIDOpenError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/msi-perkeyrgb", line 11, in <module>
    load_entry_point('msi-perkeyrgb==1.2', 'console_scripts', 'msi-perkeyrgb')()
  File "/usr/lib/python3.7/site-packages/msi_perkeyrgb/msi_perkeyrgb.py", line 90, in main
    print("Cannot open keyboard. Possible causes :\n- You don't have permissions to open the HID device. Run this program as root, or give yourself read/write permissions to the corresponding /dev/hidraw*. If you have just installed this tool, reboot your computer for the udev rule to take effect.\n- USB device with id %s is not a HID device." % id_str)
NameError: name 'id_str' is not defined
```
Becomes
```
$ msi-perkeyrgb                                                               
No laptop model specified, using GE63 as default.
Cannot open keyboard. Possible causes :
- You don't have permissions to open the HID device. Run this program as root, or give yourself read/write permissions to the corresponding /dev/hidraw*. If you have just installed this tool, reboot your computer for the udev rule to take effect.
- USB device with id None is not a HID device.
```