### PR TITLE
Allow specifying config file on stdin

### DIFF
--- a/msi_perkeyrgb/config.py
+++ b/msi_perkeyrgb/config.py
@@ -1,4 +1,5 @@
 import re
+import sys
 
 ALIAS_ALL = "all"
 ALIASES = {ALIAS_ALL: "9-133,fn",
@@ -26,9 +27,11 @@ class UnknownModelError(Exception):
 
 
 def load_config(config_path, msi_keymap):
-
     try:
-        f = open(config_path, "r")
+        if config_path == '-':
+            f = sys.stdin
+        else:
+            f = open(config_path, "r")
         config_map = parse_config(f, msi_keymap)
         f.close()
     except IOError as e:


### PR DESCRIPTION
Allow to use config file syntax via stdin to allow automation and sharing presets as runnable one-liners.

Example usage:
```
printf '25,38,39,40 steady ff0000\narrows steady 0000ff' | python3 ./msi_perkeyrgb/main.py -c -
```

Thank you for a really nice tool by the way :+1: 

Also can report MSI GL63 8SDK is working flawlessly using GE63 preset.
