### PR TITLE
Fix hid_send_feature_report failure on 64-bit systems

### DIFF
--- a/99-msi-rgb.rules
+++ b/99-msi-rgb.rules
@@ -1,1 +1,1 @@
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="113a", MODE="0666"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1122", MODE="0666"

--- a/99-msi-rgb.rules
+++ b/99-msi-rgb.rules
@@ -1,1 +1,1 @@
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1122", MODE="0666"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="113a", MODE="0666"

--- a/msi_perkeyrgb/hidapi_types.py
+++ b/msi_perkeyrgb/hidapi_types.py
@@ -25,7 +25,7 @@ def set_hidapi_types(hidapi):
     hidapi.hid_read.restype = ct.c_int
     hidapi.hid_set_nonblocking.argtypes = [ct.c_void_p, ct.c_int]
     hidapi.hid_set_nonblocking.restype = ct.c_int
-    hidapi.hid_send_feature_report.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_int]
+    hidapi.hid_send_feature_report.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_size_t]
     hidapi.hid_send_feature_report.restype = ct.c_int
     hidapi.hid_get_feature_report.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_size_t]
     hidapi.hid_get_feature_report.restype = ct.c_int


### PR DESCRIPTION
## Summary

- Fixed incorrect ctypes argtype for `hid_send_feature_report` in `hidapi_types.py`: the size parameter was declared as `ct.c_int` instead of `ct.c_size_t`, which can cause the 524-byte packet length to be silently truncated/misinterpreted on 64-bit systems
- This caused `HIDSendError: HIDAPI returned error upon sending feature report to keyboard` on MSI laptops with the newer SteelSeries KLC controller (e.g. USB product ID `1038:113a`), such as the GS76 Stealth 11UG

## Context

Related issues: #49, #52, #68 — all report `HIDSendError` on newer MSI laptops with `113a` product IDs. The root cause is this ctypes type mismatch, not a protocol difference.

The HIDAPI C function signature is:
```c
int hid_send_feature_report(hid_device *dev, const unsigned char *data, size_t length);
```

The `length` parameter is `size_t` (8 bytes on 64-bit), but was mapped to `ct.c_int` (4 bytes). This caused ctypes to push the wrong number of bytes onto the call stack, leading to undefined behavior and the `-1` error return.

## Test plan

- [x] Tested on MSI GS76 Stealth 11UG (SteelSeries KLC `1038:113a`), Gentoo Linux 6.19.6-zen1, Python 3.13, hidapi 0.15.0 — confirmed working after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)